### PR TITLE
Fix home dir expansion in setup-repo

### DIFF
--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -19,13 +19,13 @@ function ensure_pre_commit_file_exists() {
   fi 
 
   if [ -d ".git" ]; then
-    $(mkdir -p "~/.git/hooks");
+    $(mkdir -p ".git/hooks");
   elif [ -e ".git" ]; then
     # grab the git dir from our .git file, listed as 'gitdir: blah/blah/foo'
     git_dir=$(grep gitdir .git | cut -d ' ' -f 2)
     pre_commit_file="$git_dir/hooks/pre-commit"
   else
-    $(mkdir -p "~/.git/hooks");
+    $(mkdir -p ".git/hooks");
   fi
 
   $(touch $pre_commit_file)


### PR DESCRIPTION
- The hooks directory was meant to be created in $HOME/.git/hooks
but that was not working in all bash environments because of the
use of ~ and not $HOME. ~ was not being expanded.

- Changed to '.git/hooks' which is inside the project dir. If we
want to setup the repo dir, that makes no sense to me to use the
global .git dir. People may not want space commander in all obj-c
projects and for sure they dont want it in non obj-c projects.