### PR TITLE
Fixes to setup-repo.sh

### DIFF
--- a/format-objc-hook
+++ b/format-objc-hook
@@ -23,7 +23,7 @@ function format_objc() {
 	
     if [ $difference -gt 0 ]; then
     	# This is what the dev can run to fixup an individual file
-    	echo "$DIR/format-objc-file.sh '$file' && git add '$file';"
+    	echo "\"$DIR\"/format-objc-file.sh '$file' && git add '$file';"
     	success=1
     fi
   done
@@ -31,6 +31,6 @@ function format_objc() {
 }
 
 success=0
-format_objc || (echo -e "🔴  There were formatting issues with this commit, fix by running the👆 above👆 commands. \n\tYou can also run: $DIR/format-objc-files.sh\n💔  Commit anyway and skip this check by running git commit --no-verify" && success=1)
+format_objc || (echo -e "🔴  There were formatting issues with this commit, fix by running the👆 above👆 commands. \n\tYou can also run: \"$DIR\"/format-objc-files.sh\n💔  Commit anyway and skip this check by running git commit --no-verify" && success=1)
 
 exit $success

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -47,22 +47,14 @@ function ensure_hook_is_installed() {
 }
 
 function ensure_git_ignores_clang_format_file() {
-  # if .clang-format is already in the git tree then it doesn't need to be added to the ignore file
-  pushd "$DIR"
-  git ls-files .clang-format --error-unmatch > /dev/null
-  in_tree=$?
-  popd
   grep -q ".clang-format" ".gitignore"
-  if [ $? -gt 0 -a $in_tree -gt 0 ]; then
+  if [ $? -gt 0 ]; then
     echo ".clang-format" >> ".gitignore"
   fi
 }
 
 function symlink_clang_format() {
-  # only symlink .clang-format if it doesn't exist already
-  if [ ! -e "$DIR/.clang-format" ]; then
-    $(ln -sf "$DIR/.clang-format" ".clang-format")
-  fi
+  $(ln -sf "$DIR/.clang-format" ".clang-format")
 }
 
 


### PR DESCRIPTION
- Commit hook was missing shebang
- Commit hook wasn't working correctly with spaces in the repository path
- .clang-format is no longer overwritten with a symlink if it exists already
- .clang-format is no longer added to .gitignore if it's already part of the git tree