### PR TITLE
.formatting-directory can now contain multiple directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This way, we can check the formatting as part of the build process, and fail the
 Configuration
 -------------
 
-To format files within a single directory only (just one of these is supported at this time), specify the name of this directory in a file named .formatting-directory. Otherwise, all Objective-C files tracked in the repo will be checked.
+To format files only within selected directories, specify the name each directory in a file named `.formatting-directory`, separated by newlines (and without whitespace escaped). Otherwise, all Objective-C files tracked in the repo will be checked.
 
 To modify the formatting output, edit the following:
 

--- a/lib/common-lib.sh
+++ b/lib/common-lib.sh
@@ -8,11 +8,12 @@ IFS=$'\n'
 # If the repo contains a .formatting-directory file, only files in the specified directories will be returned (one directory per line).
 # If .formatting-directory doesn't exist then all files in the repository are checked.
 function directories_to_check() {
-    locations_to_diff=''
+	locations_to_diff=''
 	[ -e ".formatting-directory" ] && locations_to_diff=$( cat .formatting-directory | sed 's/ /\\ /g' );
 }
 
 # Returns a list of Objective-C files to format.
+# If .formatting-directory exists, then only directories specified in .formatting-directory will be included (see directories_to_check).
 # No parameters: return staged ObjC files only
 # Optional parameter: a git SHA. Returns a list of all ObjC files which have changed since that SHA
 function objc_files_to_format() {
@@ -24,6 +25,7 @@ function objc_files_to_format() {
 }
 
 # Returns a list of all Objective-C files in the git repository.
+# If .formatting-directory exists, then only directories specified in .formatting-directory will be included (see directories_to_check).
 function all_valid_objc_files_in_repo() {
 	directories_to_check
 	files=$(git ls-tree --name-only --full-tree -r HEAD -- $locations_to_diff | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')

--- a/lib/common-lib.sh
+++ b/lib/common-lib.sh
@@ -5,28 +5,27 @@
 
 IFS=$'\n'
 
+# If the repo contains a .formatting-directory file, only files in the specified directories will be returned (one directory per line).
+# If .formatting-directory doesn't exist then all files in the repository are checked.
+function directories_to_check() {
+    locations_to_diff=''
+	[ -e ".formatting-directory" ] && locations_to_diff=$( cat .formatting-directory | sed 's/ /\\ /g' );
+}
+
 # Returns a list of Objective-C files to format.
 # No parameters: return staged ObjC files only
 # Optional parameter: a git SHA. Returns a list of all ObjC files which have changed since that SHA
-# 
-# If the repo contains a .formatting-directory file, only files in the specified directory will be returned.
 function objc_files_to_format() {
 	optional_base_sha="$1"
-
-	location_to_diff=''
-	[ -e ".formatting-directory" ] && location_to_diff=$( cat .formatting-directory );
-
+	directories_to_check
 	# optional_base_sha is intentionally unescaped so that it will not appear as empty quotes.
-	files=$(git diff --cached --name-only $optional_base_sha --diff-filter=ACM -- "$location_to_diff" | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')
+	files=$(git diff --cached --name-only $optional_base_sha --diff-filter=ACM -- $locations_to_diff | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')
 	echo "$files" | grep -v 'Pods/' | grep -v 'Carthage/' >&1
 }
 
 # Returns a list of all Objective-C files in the git repository.
-# If the repo contains a .formatting-directory file, only files in the specified directory will be returned.
 function all_valid_objc_files_in_repo() {
-	location_to_diff=''
-	[ -e ".formatting-directory" ] && location_to_diff=$( cat .formatting-directory );
-
-	files=$(git ls-tree --name-only --full-tree -r HEAD -- "$location_to_diff" | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')
+	directories_to_check
+	files=$(git ls-tree --name-only --full-tree -r HEAD -- $locations_to_diff | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')
 	echo "$files" | grep -v 'Pods/' | grep -v 'Carthage/' >&1
 }


### PR DESCRIPTION
common-lib.sh will now check .formatting-directory for multiple lines. This makes it easier to support the standard Xcode project format where there's one directory per target.

Ideally I'd be able to exclude individual directories or files, but this is a pretty good solution and works without any other changes.