### PR TITLE
Example with completion block.

### DIFF
--- a/Testing Support/FormattedExample.m
+++ b/Testing Support/FormattedExample.m
@@ -76,6 +76,15 @@ struct Update {
     NSArray *testLiteral = @[ cool ];
     NSDictionary *dictLiteral = @{ @"foo" : testLiteral };
     SQCheckCondition(NO, , @"Will the commas stay together?");
+
+    [deviceManager syncDatasByIndexes:indexes finish:^{
+	[self doSomething]; // not formatted
+    }];
+
+    [deviceManager syncDatasByIndexes:indexes
+                               finish:^{
+     [self doSomething]; // not formatted
+                               }];
 }
 
 - (BOOL)methodThatReturnsSomething

--- a/Testing Support/UnformattedExample.m
+++ b/Testing Support/UnformattedExample.m
@@ -78,6 +78,15 @@ struct Update {
 	NSArray* testLiteral = @[cool];
 	NSDictionary* dictLiteral = @{ @"foo": testLiteral };
 	SQCheckCondition(NO,, @"Will the commas stay together?");
+
+	[deviceManager syncDatasByIndexes:indexes finish:^{
+	[self doSomething]; // not formatted
+	}];
+
+	[deviceManager syncDatasByIndexes:indexes
+							   finish:^{
+     [self doSomething]; // not formatted
+							  }];
 }
 
 -(BOOL)methodThatReturnsSomething {


### PR DESCRIPTION
This is the block before formatted:
![image](https://cloud.githubusercontent.com/assets/4676655/12666561/18e47d50-c67d-11e5-91fd-5b7ec3ad401c.png)
Then I format the file:
![image](https://cloud.githubusercontent.com/assets/4676655/12666588/4ecbe96c-c67d-11e5-8ab3-68c70ae479cb.png)
Nothing happened:
![image](https://cloud.githubusercontent.com/assets/4676655/12666612/701371c6-c67d-11e5-820a-b7cd6b95f093.png)

So I declaim it "not formatted"