### PR TITLE
Fix #42, where a trailing parameter is indented on a newline after a …

### DIFF
--- a/SpaceCommander.podspec
+++ b/SpaceCommander.podspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Pod::Spec.new do |s|
   s.name         = "SpaceCommander"
-  s.version      = "1.1.5"
+  s.version      = "1.1.6"
   s.summary      = "[ SpaceCommander] provides tools which enable you to commit Objective-C code to a git repository using a unified style format."
   s.homepage     = "https://github.com/square/spacecommander"
   s.license      = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }

--- a/Testing Support/FormattedExample.m
+++ b/Testing Support/FormattedExample.m
@@ -175,5 +175,33 @@ BOOL CStyleMethod()
     return false;
 }
 
+INSAFSuccessBlock INSAPIClientModelSuccessHandler(Class mantleClass, NSString *__nullable keyPath, INSHTTPSuccess __nullable success, INSHTTPFailure __nullable failure)
+{
+    return INSAPIClientModelSuccessChain(mantleClass, keyPath, ^(__kindof INSModel *model, id _) {
+        if (success) {
+            success(model);
+        }
+    }, failure);
+}
+
+- (void)fetchWithSuccess:(nullable dispatch_block_t)success failure:(nullable INSHTTPFailure)failure
+{
+    [self GET:@"data" parameters:nil success:INSAPIClientModelArraySuccessChain([INSModel class], nil, ^(INSModel *model, id responseObject) {
+        if (success) {
+            success();
+        }
+    }, failure) failure:failure];
+}
+
+- (void)postWithSuccess:(nullable INSHTTPSuccess)success failure:(nullable INSHTTPFailure)failure
+{
+    id imageData = nil;
+    [self POST:@"endpoint" parameters:nil constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
+        if (imageData) {
+            [formData appendPartWithFileData:imageData name:@"image" fileName:@"photo.jpg" mimeType:@"image/jpeg"];
+        }
+    } success:INSAPIClientEmptySuccessHandler(success) failure:failure];
+}
+
 
 @end

--- a/Testing Support/UnformattedExample.m
+++ b/Testing Support/UnformattedExample.m
@@ -174,6 +174,36 @@ BOOL CStyleMethod()
   return false;
 }
 
+INSAFSuccessBlock INSAPIClientModelSuccessHandler(Class mantleClass, NSString *__nullable keyPath, INSHTTPSuccess __nullable success, INSHTTPFailure __nullable failure)
+{
+    return INSAPIClientModelSuccessChain(mantleClass, keyPath, ^(__kindof INSModel *model, id _) {
+        if (success) {
+            success(model);
+        }
+    }, failure);
+
+
+}
+
+- (void)fetchWithSuccess:(nullable dispatch_block_t)success failure:(nullable INSHTTPFailure)failure
+{
+    [self GET:@"data" parameters:nil success:INSAPIClientModelArraySuccessChain([INSModel class], nil, ^(INSModel *model, id responseObject) {
+        if (success) {
+            success();
+        }
+    }, failure) failure:failure];
+
+}
+
+- (void)postWithSuccess:(nullable INSHTTPSuccess)success failure:(nullable INSHTTPFailure)failure
+{
+    id imageData = nil;
+    [self POST:@"endpoint" parameters:nil constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
+        if (imageData) {
+            [formData appendPartWithFileData:imageData name:@"image" fileName:@"photo.jpg" mimeType:@"image/jpeg"];
+        }
+    } success:INSAPIClientEmptySuccessHandler(success) failure:failure];
+}
 
 
 @end

--- a/custom/ParameterAfterBlockNewline.py
+++ b/custom/ParameterAfterBlockNewline.py
@@ -1,0 +1,44 @@
+# ParameterAfterBlockNewline.py
+# Puts parameters following a block argument back on the same line instead of REALLY indenting on the next.
+#
+# If a filename is specified as a parameter, it will change that file in place.
+# If input is provided through stdin, it will send the result to stdout.
+# Copyright 2016 Square, Inc
+
+from AbstractCustomFormatter import AbstractCustomFormatter
+
+class ParameterAfterBlockNewline(AbstractCustomFormatter):
+    def format_lines(self, lines):
+        lines_to_write = []
+        preceding_line_block_literal_param = False
+
+        for line in lines:
+            stripped_line = line.strip()
+            indentation_len = len(line) - len(line.lstrip())
+            # Some rough heuristics to determine if there's a stray, floating param which broke off from a message send
+            final_adrift_param = preceding_line_block_literal_param and stripped_line.endswith(";") and indentation_len > 8
+            adrift_param = preceding_line_block_literal_param and stripped_line.endswith(")") and indentation_len > 8 
+            if final_adrift_param:
+                preceding_line_block_literal_param = False
+
+            if final_adrift_param or adrift_param:
+                block_param_line = lines_to_write[-1].rstrip()
+                lines_to_write[-1] = block_param_line + " " + line.lstrip()
+                continue
+
+            # Match "}," exactly, 
+            if stripped_line == "},":
+                preceding_line_block_literal_param = True
+            # also match a line that starts with a brace, and has a parameter and is not the end of a statement.
+            elif stripped_line.startswith("} ") and ":" in stripped_line and ";" not in stripped_line and "{" not in stripped_line:
+                preceding_line_block_literal_param = True
+            else:
+                preceding_line_block_literal_param = False
+
+            lines_to_write.append(line)
+
+        return "".join(lines_to_write)
+
+    
+if __name__ == "__main__":
+    ParameterAfterBlockNewline().run()

--- a/format-objc-file-dry-run.sh
+++ b/format-objc-file-dry-run.sh
@@ -20,6 +20,7 @@ python "$DIR"/custom/MacroSemicolonAppender.py | \
 python "$DIR"/custom/DoubleNewlineInserter.py | \
 "$DIR"/bin/clang-format-3.8-custom -style=file | \
 python "$DIR"/custom/GenericCategoryLinebreakIndentation.py | \
+python "$DIR"/custom/ParameterAfterBlockNewline.py | \
 python "$DIR"/custom/HasIncludeSpaceRemover.py | \
 python "$DIR"/custom/NewLineAtEndOfFileInserter.py
 

--- a/format-objc-file.sh
+++ b/format-objc-file.sh
@@ -30,6 +30,8 @@ python "$DIR"/custom/DoubleNewlineInserter.py "$1"
 "$DIR"/bin/clang-format-3.8-custom -i -style=file "$1" ;
 # Fix an issue with clang-format getting confused by categories with generic expressions.
 python "$DIR"/custom/GenericCategoryLinebreakIndentation.py "$1"
+# Fix an issue with clang-format breaking up a lone parameter onto a newline after a block literal argument.
+python "$DIR"/custom/ParameterAfterBlockNewline.py "$1"
 # Fix an issue with clang-format inserting spaces in a preprocessor macro.
 python "$DIR"/custom/HasIncludeSpaceRemover.py "$1"
 # Add a newline at the end of the file


### PR DESCRIPTION
…block literal.

@msanders this is based on the fix for #41, let me know how that looks