### PR TITLE
Add directories to ignore configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Configuration
 
 To format files only within selected directories, specify the name each directory in a file named `.formatting-directory`, separated by newlines (and without whitespace escaped). Otherwise, all Objective-C files tracked in the repo will be checked.
 
+To ignore files within directories, add the name of each directory on a new line to a file named `.formatting-directory-ignore`.
+
 To modify the formatting output, edit the following:
 
 * `.clang-format` for built in `clang-format` options.

--- a/lib/common-lib.sh
+++ b/lib/common-lib.sh
@@ -12,8 +12,16 @@ function directories_to_check() {
 	[ -e ".formatting-directory" ] && locations_to_diff=$( cat .formatting-directory );
 }
 
+# If the repo contains a .formatting-directory-ignore file, files in the specified directories will be ignored (one directory per line).
+function directories_to_ignore() {
+	if [ -f ".formatting-directory-ignore" ]; then
+		files=$(echo "$files" | grep -v -f .formatting-directory-ignore)
+	fi
+}
+
 # Returns a list of Objective-C files to format.
 # If .formatting-directory exists, then only directories specified in .formatting-directory will be included (see directories_to_check).
+# If .formatting-directory-ignore exists, then directories specified in .formatting-directory-ignore will be excluded (see directories_to_ignore).
 # No parameters: return staged ObjC files only
 # Optional parameter: a git SHA. Returns a list of all ObjC files which have changed since that SHA
 function objc_files_to_format() {
@@ -21,13 +29,16 @@ function objc_files_to_format() {
 	directories_to_check
 	# optional_base_sha is intentionally unescaped so that it will not appear as empty quotes.
 	files=$(git diff --cached --name-only $optional_base_sha --diff-filter=ACM -- $locations_to_diff | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')
+	directories_to_ignore
 	echo "$files" | grep -v 'Pods/' | grep -v 'Carthage/' >&1
 }
 
 # Returns a list of all Objective-C files in the git repository.
 # If .formatting-directory exists, then only directories specified in .formatting-directory will be included (see directories_to_check).
+# If .formatting-directory-ignore exists, then directories specified in .formatting-directory-ignore will be excluded (see directories_to_ignore). 
 function all_valid_objc_files_in_repo() {
 	directories_to_check
 	files=$(git ls-tree --name-only --full-tree -r HEAD -- $locations_to_diff | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')
+	directories_to_ignore
 	echo "$files" | grep -v 'Pods/' | grep -v 'Carthage/' >&1
 }


### PR DESCRIPTION
`common-lib.sh` will now ignore files in directories listed in `.formatting-directories-ignore`. Included usage under the configuration section in the README.

Related issue: https://github.com/square/spacecommander/issues/49
