### PR TITLE
Fix unassigned variable error

### DIFF
--- a/custom/DoubleNewlineInserter.py
+++ b/custom/DoubleNewlineInserter.py
@@ -12,6 +12,7 @@ class DoubleNewlineInserter(AbstractCustomFormatter):
         lines_to_write = []
         needs_double_newline_added = False
         comment_section = False
+        in_multiline_comment = False
         for line in lines:
             stripped_line = line.strip()
             # Leave macros alone


### PR DESCRIPTION
```
UnboundLocalError: local variable 'in_multiline_comment' referenced before assignment
Traceback (most recent call last):
  File "/.../spacecommander/custom/DoubleNewlineInserter.py", line 41, in <module>
    DoubleNewlineInserter().run()
  File "/.../spacecommander/custom/AbstractCustomFormatter.py", line 15, in run
    formatted_lines = self.format_lines(f.readlines())
  File "/.../spacecommander/custom/DoubleNewlineInserter.py", line 21, in format_lines
    needs_double_newline_added = not (comment_section or in_multiline_comment)
```
