### PR TITLE
Make sure to create the hooks/ directory if it does not exist

### DIFF
--- a/SpaceCommander.podspec
+++ b/SpaceCommander.podspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Pod::Spec.new do |s|
   s.name         = "SpaceCommander"
-  s.version      = "1.1.9"
+  s.version      = "1.1.10"
   s.summary      = "[ SpaceCommander] provides tools which enable you to commit Objective-C code to a git repository using a unified style format."
   s.homepage     = "https://github.com/square/spacecommander"
   s.license      = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -24,6 +24,10 @@ function ensure_pre_commit_file_exists() {
     # grab the git dir from our .git file, listed as 'gitdir: blah/blah/foo'
     git_dir=$(grep gitdir .git | cut -d ' ' -f 2)
     pre_commit_file="$git_dir/hooks/pre-commit"
+
+    # Even if our git dir is in an unusual place, we still need to create the hook directory
+    # if it does not already exist.
+    $(mkdir -p "$git_dir/hooks");
   else
     $(mkdir -p ".git/hooks");
   fi


### PR DESCRIPTION
Sometimes, .git may be a file which contains the path to the actual .git directory.

For example, when using git worktree:
12:18 rhg@rhg-mac-pro:~/Development/r5$ cat .git
gitdir: /Users/rhg/Development/r1--ri-18669--feature-flag-for-r12-ble-background/.git/worktrees/r5

When running 'setup-repo.sh', SpaceCommander creates the 'hooks' directory in .git in all cases except this one. This prevents 'setup-repo' from working in all working copies created by git-worktree.