### PR TITLE
Clean up the echo such that the path can be easily copy pasted.

### DIFF
--- a/format-objc-hook
+++ b/format-objc-hook
@@ -26,12 +26,12 @@ function format_objc() {
             echo -e "🚸 Format and stage individual files:"
         fi
     	# This is what the dev can run to fixup an individual file
-    	echo "\"$DIR\"/format-objc-file.sh '$file' && git add '$file';"
+    	echo "${DIR}/format-objc-file.sh '$file' && git add '$file';"
     	success=1
     fi
   done
   if [ $success -gt 0 ]; then
-      echo -e "\n🚀  Format and stage all affected files:\n\t \"$DIR\"/format-objc-files.sh -s"
+      echo -e "\n🚀  Format and stage all affected files:\n\t ${DIR}/format-objc-files.sh -s"
   fi
   return $success 
 }


### PR DESCRIPTION
Currently it outputs the quotes:
```
🚸 Format and stage individual files:
"/Users/cwoodward/Development/register/Pods/SpaceCommander"/format-objc-file.sh 'Frameworks/SquarePOS/Sources/OpenTicket/UI/RQParentOpenTicketsViewController.m' && git add 'Frameworks/SquarePOS/Sources/OpenTicket/UI/RQParentOpenTicketsViewController.m';

🚀  Format and stage all affected files:
	 "/Users/cwoodward/Development/register/Pods/SpaceCommander"/format-objc-files.sh -s

🔴  There were formatting issues with this commit, run the👆 above👆 command to fix.
💔  Commit anyway and skip this check by running git commit --no-verify
```

After fix:

```
🚸 Format and stage individual files:
/Users/cwoodward/Development/register/Pods/SpaceCommander/format-objc-file.sh 'Frameworks/SquarePOS/Sources/OpenTicket/UI/RQParentOpenTicketsViewController.m' && git add 'Frameworks/SquarePOS/Sources/OpenTicket/UI/RQParentOpenTicketsViewController.m';

🚀  Format and stage all affected files:
	 /Users/cwoodward/Development/register/Pods/SpaceCommander/format-objc-files.sh -s

🔴  There were formatting issues with this commit, run the👆 above👆 command to fix.
💔  Commit anyway and skip this check by running git commit --no-verify
```