### PR TITLE
Use diff -q to compare files

### DIFF
--- a/format-objc-hook
+++ b/format-objc-hook
@@ -7,7 +7,7 @@
 
 IFS=$'\n'
 export CDPATH=""
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$DIR"/lib/common-lib.sh
 
 # Don't do anything unless a .clang-format file exists
@@ -19,21 +19,21 @@ objc_files=$(objc_files_to_format "$1")
 function format_objc() {
   success=0
   for file in $objc_files; do
-    difference=$("$DIR"/format-objc-file-dry-run.sh "$file" | diff "$file" - | wc -l)
-	
+    difference=$("$DIR"/format-objc-file-dry-run.sh "$file" | diff -q "$file" - | wc -l)
+
     if [ $difference -gt 0 ]; then
-        if [ $success -eq 0 ]; then
-            echo -e "🚸 Format and stage individual files:"
-        fi
-    	# This is what the dev can run to fixup an individual file
-    	echo "\"$DIR\"/format-objc-file.sh '$file' && git add '$file';"
-    	success=1
+      if [ $success -eq 0 ]; then
+        echo -e "🚸 Format and stage individual files:"
+      fi
+      # This is what the dev can run to fixup an individual file
+      echo "\"$DIR\"/format-objc-file.sh '$file' && git add '$file';"
+      success=1
     fi
   done
   if [ $success -gt 0 ]; then
-      echo -e "\n🚀  Format and stage all affected files:\n\t \"$DIR\"/format-objc-files.sh -s"
+    echo -e "\n🚀  Format and stage all affected files:\n\t \"$DIR\"/format-objc-files.sh -s"
   fi
-  return $success 
+  return $success
 }
 
 success=0

--- a/format-objc-mobuild
+++ b/format-objc-mobuild
@@ -8,7 +8,7 @@ IFS=$'\n'
 
 # The full path to the formatting scripts.
 export CDPATH=""
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # The (assumed) relative path to the scripts from the repo.
 # It would be better to search for this location, but it's made more difficult since this could be located as a sibling dependency for some repos.
 RELATIVE_SCRIPTS_DIR="Pods/spacecommander"
@@ -18,18 +18,17 @@ source "$DIR"/lib/common-lib.sh
 objc_files=$(objc_files_to_format "$1")
 [ -z "$objc_files" ] && exit 0
 
-
 function format_objc() {
-  success=0
-  for file in $objc_files; do
-	difference=$("$DIR"/format-objc-file-dry-run.sh "$file" | diff "$file" - | wc -l)
-	
-    if [ $difference -gt 0 ]; then
-    	echo "$RELATIVE_SCRIPTS_DIR/format-objc-file.sh '$file' && git add '$file';"
-    	success=1
-    fi
-  done
-  return $success 
+	success=0
+	for file in $objc_files; do
+		difference=$("$DIR"/format-objc-file-dry-run.sh "$file" | diff -q "$file" - | wc -l)
+
+		if [ $difference -gt 0 ]; then
+			echo "$RELATIVE_SCRIPTS_DIR/format-objc-file.sh '$file' && git add '$file';"
+			success=1
+		fi
+	done
+	return $success
 }
 
 success=0

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@
 # Test that the in-place behavior does not differ from stdout
 cp Testing\ Support/UnformattedExample.m Testing\ Support/FormattedInPlace.m
 ./format-objc-file.sh Testing\ Support/FormattedInPlace.m
-difference=$(./format-objc-file-dry-run.sh Testing\ Support/UnformattedExample.m | diff Testing\ Support/FormattedInPlace.m - | wc -l)
+difference=$(./format-objc-file-dry-run.sh Testing\ Support/UnformattedExample.m | diff -q Testing\ Support/FormattedInPlace.m - | wc -l)
 if [ "$difference" -gt 0 ]; then
     echo -e "Tests fail. Run\n\t diff <(./format-objc-file-dry-run.sh Testing\ Support/UnformattedExample.m) Testing\ Support/FormattedInPlace.m \nto see why."
     echo "Then, remove the temporary file Testing\ Support/FormattedInPlace.m"
@@ -14,23 +14,22 @@ if [ "$difference" -gt 0 ]; then
 fi
 rm Testing\ Support/FormattedInPlace.m
 
-difference=$(./format-objc-file-dry-run.sh Testing\ Support/UnformattedExample.m | diff Testing\ Support/FormattedExample.m - | wc -l)
+difference=$(./format-objc-file-dry-run.sh Testing\ Support/UnformattedExample.m | diff -q Testing\ Support/FormattedExample.m - | wc -l)
 if [ "$difference" -gt 0 ]; then
     echo -e "Tests fail. Run\n\t diff <(./format-objc-file-dry-run.sh Testing\ Support/UnformattedExample.m) Testing\ Support/FormattedExample.m \nto see why."
     exit $difference
 fi
 
-difference=$(./format-objc-file-dry-run.sh Testing\ Support/ExemptViaPragmaUnformattedExample.m | diff Testing\ Support/ExemptViaPragmaFormattedExample.m - | wc -l)
+difference=$(./format-objc-file-dry-run.sh Testing\ Support/ExemptViaPragmaUnformattedExample.m | diff -q Testing\ Support/ExemptViaPragmaFormattedExample.m - | wc -l)
 if [ "$difference" -gt 0 ]; then
     echo -e "Tests fail. Run\n\t diff <(./format-objc-file-dry-run.sh Testing\ Support/ExemptViaPragmaUnformattedExample.m) Testing\ Support/ExemptViaPragmaFormattedExample.m \nto see why."
     exit $difference
 fi
 
-difference=$(./format-objc-file-dry-run.sh Testing\ Support/ExemptViaCommentUnformattedExample.m | diff Testing\ Support/ExemptViaCommentFormattedExample.m - | wc -l)
+difference=$(./format-objc-file-dry-run.sh Testing\ Support/ExemptViaCommentUnformattedExample.m | diff -q Testing\ Support/ExemptViaCommentFormattedExample.m - | wc -l)
 if [ "$difference" -gt 0 ]; then
-  echo -e "Tests fail. Run\n\t diff <(./format-objc-file-dry-run.sh Testing\ Support/ExemptViaCommentUnformattedExample.m) Testing\ Support/ExemptViaCommentFormattedExample.m \nto see why."
-  exit $difference
+    echo -e "Tests fail. Run\n\t diff <(./format-objc-file-dry-run.sh Testing\ Support/ExemptViaCommentUnformattedExample.m) Testing\ Support/ExemptViaCommentFormattedExample.m \nto see why."
+    exit $difference
 fi
 
 echo "Tests pass"
-


### PR DESCRIPTION
This avoids constructing diffs when the actual difference is unused

Fixes #66 