### PR TITLE
[fix]: address issue when header files are interpreted as c++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,9 @@
 ---
-Language: ObjC
+# `Language` intentionally left blank to apply these rules
+# as the default formatting options.
+# This addresses an issue which can occur when clang-format
+# decides a header looks more like c++ than objc.
+
 # BasedOnStyle:  Google
 AccessModifierOffset: -1
 ConstructorInitializerIndentWidth: 4

--- a/Testing Support/ImportOnlyHeaderFormattedExample.h
+++ b/Testing Support/ImportOnlyHeaderFormattedExample.h
@@ -1,0 +1,3 @@
+
+#import <Foundation/Foundation.h>
+#import <MyLib/MyLib.h>

--- a/Testing Support/ImportOnlyHeaderUnformattedExample.h
+++ b/Testing Support/ImportOnlyHeaderUnformattedExample.h
@@ -1,0 +1,3 @@
+
+        #import <Foundation/Foundation.h>
+#import <MyLib/MyLib.h>


### PR DESCRIPTION
### Background

- when formatting a header file, clang-format implements some [heuristics](https://github.com/llvm-mirror/clang/blob/aa231e4be75ac4759c236b755c57876f76e3cf05/lib/Format/Format.cpp#L1694) to differentiate c++ vs objc files.
- in the case that you have a header file with only imports, the c++ heuristic wins, which results in an error when formatting because we don't provide a c++ formatting spec in our `.clang-format` file.

### Description

- update our format file to remove the `Language: ObjC` option, so the formatting rules apply to all files that are identified to be processed by Space Commander
