### PR TITLE
[gardening]: fix error when handling quotes/apostrophes

### DIFF
--- a/Testing Support/QuotesInFirstLineFormattedExample.m
+++ b/Testing Support/QuotesInFirstLineFormattedExample.m
@@ -1,0 +1,8 @@
+// This is a contrived example to ' exercise ` handling " of certain characters
+
+class ABC : NSObject
+{
+    - (instancetype)init
+    {
+    }
+}

--- a/Testing Support/QuotesInFirstLineUnformattedExample.m
+++ b/Testing Support/QuotesInFirstLineUnformattedExample.m
@@ -1,0 +1,7 @@
+// This is a contrived example to ' exercise ` handling " of certain characters
+
+    class ABC: NSObject {
+-(instancetype)init {
+
+                    }
+    }

--- a/format-objc-file.sh
+++ b/format-objc-file.sh
@@ -59,7 +59,10 @@ fi
 function format_objc_file_dry_run() {
 	# "#pragma Formatter Exempt" or "// MARK: Formatter Exempt" means don't format this file.
 	# Read the first line and trim it.
-	line="$(head -1 "$FILE" | xargs)"
+	line="$(head -1 "$FILE" |
+		sed "s/\'/\\\'/" |
+		sed 's/\"/\\\"/' |
+		xargs)"
 	if [ "$line" == "#pragma Formatter Exempt" -o "$line" == "// MARK: Formatter Exempt" ]; then
 		cat "$1"
 		return

--- a/test.sh
+++ b/test.sh
@@ -41,5 +41,6 @@ runTest "ExemptViaPragma" ".m"
 runTest "ExemptViaComment" ".m"
 runTest "Unicode" ".m"
 runTest "ImportOnlyHeader" ".h"
+runTest "QuotesInFirstLine" ".m"
 
 echo "Tests pass"


### PR DESCRIPTION
### Background

- `format-objc-file.sh` would fail when searching for the formatter exemption string because quotes weren't accounted for

### Description

- escape quotes before passing to `xargs`
