### PR TITLE
Consolidate pre- and post-clang-format Python steps to improve performance

### DIFF
--- a/custom/AggregatedFormatter.py
+++ b/custom/AggregatedFormatter.py
@@ -1,0 +1,16 @@
+
+from AbstractCustomFormatter import AbstractCustomFormatter
+from io import StringIO
+
+class AggregatedFormatter(AbstractCustomFormatter):
+
+    def __init__(self, formatters):
+        self.formatters = formatters
+
+    def format_lines(self, lines):
+        if len(self.formatters) == 0:
+            return "".join(lines)
+        for formatter in self.formatters:
+            formatted = formatter.format_lines(lines)
+            lines = StringIO(formatted).readlines()
+        return "".join(lines)

--- a/custom/PostClangFormatFormatter.py
+++ b/custom/PostClangFormatFormatter.py
@@ -1,0 +1,13 @@
+
+from AggregatedFormatter import AggregatedFormatter
+from GenericCategoryLinebreakIndentation import GenericCategoryLinebreakIndentation
+from ParameterAfterBlockNewline import ParameterAfterBlockNewline
+from HasIncludeSpaceRemover import HasIncludeSpaceRemover
+
+if __name__ == "__main__":
+    formatters = [
+        GenericCategoryLinebreakIndentation(),
+        ParameterAfterBlockNewline(),
+        HasIncludeSpaceRemover(),
+    ]
+    AggregatedFormatter(formatters).run()

--- a/custom/PreClangFormatFormatter.py
+++ b/custom/PreClangFormatFormatter.py
@@ -1,0 +1,15 @@
+
+from AggregatedFormatter import AggregatedFormatter
+from LiteralSymbolSpacer import LiteralSymbolSpacer
+from InlineConstructorOnSingleLine import InlineConstructorOnSingleLine
+from MacroSemicolonAppender import MacroSemicolonAppender
+from DoubleNewlineInserter import DoubleNewlineInserter
+
+if __name__ == "__main__":
+    formatters = [
+        LiteralSymbolSpacer(),
+        InlineConstructorOnSingleLine(),
+        MacroSemicolonAppender(),
+        DoubleNewlineInserter()
+    ]
+    AggregatedFormatter(formatters).run()

--- a/format-objc-file.sh
+++ b/format-objc-file.sh
@@ -81,14 +81,9 @@ function format_objc_file_dry_run() {
 	fi
 
 	cat "$1" |
-		/usr/bin/python3 "$DIR"/custom/LiteralSymbolSpacer.py |
-		/usr/bin/python3 "$DIR"/custom/InlineConstructorOnSingleLine.py |
-		/usr/bin/python3 "$DIR"/custom/MacroSemicolonAppender.py |
-		/usr/bin/python3 "$DIR"/custom/DoubleNewlineInserter.py |
+		/usr/bin/python3 "$DIR"/custom/PreClangFormatFormatter.py |
 		"$DIR"/bin/clang-format-19.1.4-fd3b4acf03680a2dafbf1d40b562f5dff1c4436f "$style" |
-		/usr/bin/python3 "$DIR"/custom/GenericCategoryLinebreakIndentation.py |
-		/usr/bin/python3 "$DIR"/custom/ParameterAfterBlockNewline.py |
-		/usr/bin/python3 "$DIR"/custom/HasIncludeSpaceRemover.py
+		/usr/bin/python3 "$DIR"/custom/PostClangFormatFormatter.py
 }
 
 function format_objc_file() {


### PR DESCRIPTION
Consolidate the various Python formatter commands into a single invocation for changes pre `clang-format` and post `clang-format` to reduce extra overhead involved in spinning up a new process for each step.

This makes a significant difference on a large internal monorepo with over 12k Objective-C files, reducing the time of `format-objc-files-in-repo.sh` from 10m53s to 6m14s (42% reduction)